### PR TITLE
fix bug due to changed method signature after issue #20 and #60

### DIFF
--- a/modules/genericormapper/data/tools/GenericORMapperManagementTool.php
+++ b/modules/genericormapper/data/tools/GenericORMapperManagementTool.php
@@ -255,7 +255,7 @@ class GenericORMapperManagementTool extends BaseMapper {
     *
     * @param boolean $updateInPlace Defines, if the update should be done for you (true) or if
     *                               the update statement should only be displayed (false).
-    *                               Default is true.
+    *                               Default is false.
     *
     * @throws GenericORMapperException In case of missing connection name.
     *
@@ -285,7 +285,7 @@ class GenericORMapperManagementTool extends BaseMapper {
       // $setup->setContext('blah');
       // $setup->addMappingConfiguration('VENDOR\path\to\my\application', 'foo');
       // $setup->addMappingConfiguration('VENDOR\path\to\my\application', 'bar');
-      // $setup->run();
+      // $setup->run(true);
       if (!empty($this->configNamespace) && !empty($this->configNameAffix)) {
          $this->addMappingConfiguration($this->configNamespace, $this->configNameAffix);
          $this->addRelationConfiguration($this->configNamespace, $this->configNameAffix);

--- a/modules/guestbook2009/data/setup/setup.php
+++ b/modules/guestbook2009/data/setup/setup.php
@@ -20,4 +20,4 @@ $setup->setContext($context);
 $setup->addMappingConfiguration('APF\modules\guestbook2009\data', 'guestbook2009');
 $setup->addRelationConfiguration('APF\modules\guestbook2009\data', 'guestbook2009');
 $setup->setConnectionName($connectionKey);
-$setup->run();
+$setup->run(true);


### PR DESCRIPTION
while refactoring the GenericOrMapperManagementTool the signature of the method run()
was changed. default value is now false.
