### PR TITLE
ISSUE#343: Use Mime Type Validation and File Size Validator without U…

### DIFF
--- a/tools/form/validator/FileSizeValidator.php
+++ b/tools/form/validator/FileSizeValidator.php
@@ -33,8 +33,9 @@ use APF\tools\validation\NumberScopeValidator as NumberScopeValidatorImpl;
  */
 class FileSizeValidator extends TextFieldValidator {
 
-   private static $MAX_ALLOWED_SIZE_ATTRIBUTE_NAME = 'maxsize';
+   private static $MAX_ALLOWED_SIZE_ATTRIBUTE_NAME  = 'maxsize';
    private static $MIN_REQUIRED_SIZE_ATTRIBUTE_NAME = 'minsize';
+   private static $UPLOAD_REQUIRED                  = 'uploadrequired';
 
    /**
     * Validates the file control attached to.
@@ -67,7 +68,20 @@ class FileSizeValidator extends TextFieldValidator {
          return $validator->isValid($size);
       }
 
-      return false;
+      return ($this->getUploadRequeired()) ? FALSE : TRUE;
+   }
+
+   /**
+    * Is a file upload required
+    * @return bool
+    */
+   private function getUploadRequeired() {
+      $uploadRequired = $this->control->getAttribute(self::$UPLOAD_REQUIRED);
+      if (empty($uploadRequired)) {
+         return TRUE;
+      }
+
+      return (strtolower($uploadRequired) == 'false') ? FALSE : TRUE;
    }
 
    /**

--- a/tools/form/validator/MimeTypeValidator.php
+++ b/tools/form/validator/MimeTypeValidator.php
@@ -65,6 +65,8 @@ class MimeTypeValidator extends TextFieldValidator {
             return true;
          }
 
+         return false;
+
       }
 
       return ($this->getUploadRequeired()) ? FALSE : TRUE;

--- a/tools/form/validator/MimeTypeValidator.php
+++ b/tools/form/validator/MimeTypeValidator.php
@@ -21,6 +21,7 @@
 namespace APF\tools\form\validator;
 
 use APF\tools\form\taglib\FileUploadTag;
+use GWPORTAL\pres\controller\frontend\content\faq\FaqListController;
 
 /**
  * Implements a simple validator, that checks the uploaded file
@@ -33,6 +34,8 @@ use APF\tools\form\taglib\FileUploadTag;
 class MimeTypeValidator extends TextFieldValidator {
 
    private static $ACCEPTS_ATTRIBUTE_NAME = 'accepts';
+   private static $UPLOAD_DUTY            = 'true';
+   private static $UPLOAD_REQUIRED        = 'uploadrequired';
 
    /**
     * Validates the file control attached to.
@@ -64,8 +67,21 @@ class MimeTypeValidator extends TextFieldValidator {
 
       }
 
-      return false;
+      return ($this->getUploadRequeired()) ? FALSE : TRUE;
 
+   }
+
+   /**
+    * Is a file upload required
+    * @return bool
+    */
+   private function getUploadRequeired() {
+      $uploadRequired = $this->control->getAttribute(self::$UPLOAD_REQUIRED);
+      if (empty($uploadRequired)) {
+         return TRUE;
+      }
+
+      return (strtolower($uploadRequired) == 'false') ? FALSE : TRUE;
    }
 
    /**


### PR DESCRIPTION
Diese erweiterung gibt immer noch das bekannte verhalten zurück. Jedoch kann man es mit dem Attribut uploadrequired="false" deaktiveiren und die Validatoren geben bei einem nicht Upload TRUE statt FALSE zurück.