### PR TITLE
ISSUE#345: E-Mail Versand ContentType falsch

### DIFF
--- a/tests/suites/tools/mail/MessageTest.php
+++ b/tests/suites/tools/mail/MessageTest.php
@@ -55,7 +55,7 @@ class MessageTest extends TestCase {
             $message->getContent()
       );
       $this->assertEquals(
-            'plain/text; charset=' . Registry::retrieve('APF\core', 'Charset'),
+            'text/plain; charset=' . Registry::retrieve('APF\core', 'Charset'),
             $message->getContentType()
       );
    }
@@ -184,7 +184,7 @@ class MessageTest extends TestCase {
       $this->assertEquals('From: ' . $sender . PHP_EOL
             . 'CC: ' . $sender . PHP_EOL
             . 'BCC: ' . $sender . PHP_EOL
-            . 'Content-Type: plain/text; charset=UTF-8' . PHP_EOL
+            . 'Content-Type: text/plain; charset=UTF-8' . PHP_EOL
             . 'Return-Path: ' . $sender->getEmail() . PHP_EOL
             . 'X-Priority: 3' . PHP_EOL
             . 'MIME-Version: 1.0' . PHP_EOL

--- a/tools/mail/Message.php
+++ b/tools/mail/Message.php
@@ -87,7 +87,7 @@ class Message {
       $this->subject = $subject;
       $this->content = $content;
 
-      $this->contentType = 'plain/text; charset=' . Registry::retrieve('APF\core', 'Charset');
+      $this->contentType = 'text/plain; charset=' . Registry::retrieve('APF\core', 'Charset');
    }
 
    /**


### PR DESCRIPTION
Naja fällt glaube ich niemanden auf der nur HTML Mails versenden weil er den Content Type ändert.